### PR TITLE
feat(notifications): push notify on new direct chats and initial grou…

### DIFF
--- a/backend/auth-service/src/main/java/com/orang/authservice/service/AuthService.java
+++ b/backend/auth-service/src/main/java/com/orang/authservice/service/AuthService.java
@@ -47,7 +47,7 @@ public class AuthService {
     @Transactional
     public RegistrationResponse register(RegisterRequest registerRequest){
         if (userRepository.existsByEmail(registerRequest.getEmail().toLowerCase())) {
-            throw new BadRequestException("Email already exists");
+            throw new BadRequestException("Invalid email or password");
         }
 
         User user = User.builder()

--- a/backend/message-service/pom.xml
+++ b/backend/message-service/pom.xml
@@ -149,6 +149,48 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>check-core-services-coverage</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <includes>
+                                        <include>com/orang/messageservice/service/MessageService</include>
+                                        <include>com/orang/messageservice/service/ReactionService</include>
+                                        <include>com/orang/messageservice/service/MentionParserService</include>
+                                        <include>com/orang/messageservice/service/ConversationService</include>
+                                        <include>com/orang/messageservice/service/ReadReceiptService</include>
+                                        <include>com/orang/messageservice/service/PinnedMessageService</include>
+                                        <include>com/orang/messageservice/service/AttachmentService</include>
+                                        <include>com/orang/messageservice/service/MessageSearchService</include>
+                                        <include>com/orang/messageservice/service/GroupEventService</include>
+                                        <include>com/orang/messageservice/service/JwtService</include>
+                                        <include>com/orang/messageservice/service/MessageEventPublisher</include>
+                                        <include>com/orang/messageservice/service/ThumbnailService</include>
+                                        <include>com/orang/messageservice/service/MinioFileStorageService</include>
+                                    </includes>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/backend/message-service/src/main/java/com/orang/messageservice/mapper/MessageMapper.java
+++ b/backend/message-service/src/main/java/com/orang/messageservice/mapper/MessageMapper.java
@@ -66,8 +66,6 @@ public class MessageMapper {
         Map<ReactionType, Long> counts = reactionService.getReactionCounts(message.getId());
         builder.reactionCounts(counts);
 
-        // `myReaction` removed — full reaction entries are available in `reactions` list.
-
         List<MessageReaction> reactions = messageReactionRepository.findByMessageId(message.getId());
         if (reactions != null && !reactions.isEmpty()) {
             builder.reactions(reactions.stream().map(r -> MessageResponse.ReactionInfo.builder()

--- a/backend/message-service/src/main/java/com/orang/messageservice/service/ConversationService.java
+++ b/backend/message-service/src/main/java/com/orang/messageservice/service/ConversationService.java
@@ -22,6 +22,7 @@ public class ConversationService {
 
     private final ConversationRepository conversationRepository;
     private final GroupEventService groupEventService;
+    private final ConversationNotificationEventService conversationNotificationEventService;
 
     public List<ConversationResponse> getConversations(UUID userId) {
         List<Conversation> conversations = conversationRepository.findByParticipantIdsContaining(userId);
@@ -50,7 +51,16 @@ public class ConversationService {
         addParticipant(newConversation, userId1, ConversationParticipant.ParticipantRole.MEMBER, null);
         addParticipant(newConversation, userId2, ConversationParticipant.ParticipantRole.MEMBER, null);
 
-        return toConversationResponse(conversationRepository.save(newConversation));
+        Conversation savedConversation = conversationRepository.save(newConversation);
+
+        // Notify the recipient that a new direct chat was created.
+        conversationNotificationEventService.directConversationCreated(
+            savedConversation.getId(),
+            userId1,
+            userId2
+        );
+
+        return toConversationResponse(savedConversation);
     }
 
     @Transactional
@@ -76,7 +86,16 @@ public class ConversationService {
             }
         }
 
-        return toConversationResponse(conversationRepository.save(newConversation));
+        Conversation savedConversation = conversationRepository.save(newConversation);
+
+        // Emit member-added events for initial group members (except creator).
+        for (UUID participantId : participantIds) {
+            if (!participantId.equals(creatorId)) {
+                groupEventService.memberAdded(savedConversation.getId(), participantId, creatorId);
+            }
+        }
+
+        return toConversationResponse(savedConversation);
     }
 
     private void addParticipant(Conversation conversation, UUID userId,

--- a/backend/message-service/src/main/java/com/orang/messageservice/service/MessageSearchService.java
+++ b/backend/message-service/src/main/java/com/orang/messageservice/service/MessageSearchService.java
@@ -106,7 +106,7 @@ public class MessageSearchService {
                 combinedMessages.getLast().getCreatedAt());
 
         List<MessageResponse> messageDtos = combinedMessages.stream()
-                .map(messageMapper::toMessageResponse)
+                .map(foundMessage -> messageMapper.toMessageResponse(foundMessage, userId))
                 .toList();
 
         log.debug("Messages around {}: {} messages found", messageId, combinedMessages.size());

--- a/backend/message-service/src/main/java/com/orang/messageservice/service/MessageService.java
+++ b/backend/message-service/src/main/java/com/orang/messageservice/service/MessageService.java
@@ -75,7 +75,7 @@ public class MessageService {
         if (messageId != null && messageRepository.existsById(messageId)) {
             log.info("Message {} already exists, returning existing", messageId);
             Message existing = messageRepository.findById(messageId).orElseThrow();
-            return messageMapper.toMessageResponse(existing);
+                        return messageMapper.toMessageResponse(existing, senderId);
         }
 
         // Validate reply reference

--- a/backend/message-service/src/main/resources/application.yaml
+++ b/backend/message-service/src/main/resources/application.yaml
@@ -38,6 +38,7 @@ jwt:
 
 minio:
   endpoint: ${MINIO_ENDPOINT:http://minio:9000}
+  external-endpoint: ${MINIO_EXTERNAL_ENDPOINT:${MINIO_ENDPOINT:http://minio:9000}}
   access-key: ${MINIO_ACCESS_KEY:minioadmin}
   secret-key: ${MINIO_SECRET_KEY:minioadmin123}
   bucket-name: ${MINIO_BUCKET_NAME:chat-attachments}

--- a/backend/message-service/src/test/java/com/orang/messageservice/MessageServiceApplicationTests.java
+++ b/backend/message-service/src/test/java/com/orang/messageservice/MessageServiceApplicationTests.java
@@ -1,13 +1,13 @@
 package com.orang.messageservice;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@SpringBootTest
 class MessageServiceApplicationTests {
 
     @Test
-    void contextLoads() {
+    void packageStructureSanityCheck() {
+        assertEquals("com.orang.messageservice", MessageServiceApplication.class.getPackageName());
     }
 
 }

--- a/backend/message-service/src/test/java/com/orang/messageservice/service/MentionParserServiceTest.java
+++ b/backend/message-service/src/test/java/com/orang/messageservice/service/MentionParserServiceTest.java
@@ -1,0 +1,44 @@
+package com.orang.messageservice.service;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MentionParserServiceTest {
+
+    private final MentionParserService mentionParserService = new MentionParserService();
+
+    @Test
+    void extractMentionsReturnsEmptyForNullAndBlank() {
+        assertTrue(mentionParserService.extractMentions(null).isEmpty());
+        assertTrue(mentionParserService.extractMentions("   ").isEmpty());
+    }
+
+    @Test
+    void extractMentionsParsesUuidMentionsCaseInsensitiveAndDeduplicates() {
+        UUID userId = UUID.randomUUID();
+        String content = "hello @" + userId + " and again @" + userId.toString().toUpperCase();
+
+        Set<UUID> mentioned = mentionParserService.extractMentions(content);
+
+        assertEquals(1, mentioned.size());
+        assertTrue(mentioned.contains(userId));
+    }
+
+    @Test
+    void validateMentionsKeepsOnlyConversationParticipants() {
+        UUID participant = UUID.randomUUID();
+        UUID outsider = UUID.randomUUID();
+
+        Set<UUID> validated = mentionParserService.validateMentions(
+                Set.of(participant, outsider),
+                Set.of(participant)
+        );
+
+        assertEquals(Set.of(participant), validated);
+    }
+}

--- a/backend/message-service/src/test/java/com/orang/messageservice/service/MessageServiceTest.java
+++ b/backend/message-service/src/test/java/com/orang/messageservice/service/MessageServiceTest.java
@@ -1,0 +1,437 @@
+package com.orang.messageservice.service;
+
+import com.orang.messageservice.dto.MessageResponse;
+import com.orang.messageservice.entity.Conversation;
+import com.orang.messageservice.entity.ConversationParticipant;
+import com.orang.messageservice.entity.ConversationParticipantId;
+import com.orang.messageservice.entity.Message;
+import com.orang.messageservice.entity.MessageMention;
+import com.orang.messageservice.mapper.MessageMapper;
+import com.orang.messageservice.repository.ConversationRepository;
+import com.orang.messageservice.repository.MessageMentionRepository;
+import com.orang.messageservice.repository.MessageRepository;
+import com.orang.shared.exception.ForbiddenException;
+import com.orang.shared.exception.ResourceNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MessageServiceTest {
+
+	@Mock
+	private MessageRepository messageRepository;
+
+	@Mock
+	private ConversationRepository conversationRepository;
+
+	@Mock
+	private ConversationService conversationService;
+
+	@Mock
+	private MessageMapper messageMapper;
+
+	@Mock
+	private MessageEventPublisher messageEventPublisher;
+
+	@Mock
+	private AttachmentService attachmentService;
+
+	@Mock
+	private MentionParserService mentionParserService;
+
+	@Mock
+	private MessageMentionRepository messageMentionRepository;
+
+	@InjectMocks
+	private MessageService messageService;
+
+	private UUID conversationId;
+	private UUID senderId;
+	private UUID otherUserId;
+	private Conversation conversation;
+
+	@BeforeEach
+	void setUp() {
+		conversationId = UUID.randomUUID();
+		senderId = UUID.randomUUID();
+		otherUserId = UUID.randomUUID();
+
+		conversation = Conversation.builder()
+				.id(conversationId)
+				.participants(Set.of(
+						participant(conversationId, senderId),
+						participant(conversationId, otherUserId)
+				))
+				.build();
+	}
+
+	@Test
+	void getMessagesForConversationThrowsWhenConversationMissing() {
+		UUID requesterId = UUID.randomUUID();
+		Pageable pageable = PageRequest.of(0, 10);
+
+		when(conversationRepository.findById(conversationId)).thenReturn(Optional.empty());
+
+		assertThrows(ResourceNotFoundException.class,
+				() -> messageService.getMessagesForConversation(conversationId, requesterId, pageable));
+	}
+
+	@Test
+	void getMessagesForConversationThrowsWhenRequesterNotParticipant() {
+		UUID requesterId = UUID.randomUUID();
+		Pageable pageable = PageRequest.of(0, 10);
+
+		when(conversationRepository.findById(conversationId)).thenReturn(Optional.of(conversation));
+
+		assertThrows(ForbiddenException.class,
+				() -> messageService.getMessagesForConversation(conversationId, requesterId, pageable));
+	}
+
+	@Test
+	void getMessagesForConversationReturnsMappedPageForParticipant() {
+		Pageable pageable = PageRequest.of(0, 10);
+		Message message = Message.builder()
+				.id(UUID.randomUUID())
+				.conversationId(conversationId)
+				.senderId(senderId)
+				.content("hello")
+				.createdAt(LocalDateTime.now())
+				.build();
+
+		MessageResponse response = MessageResponse.builder()
+				.id(message.getId())
+				.conversationId(conversationId)
+				.senderId(senderId)
+				.content("hello")
+				.build();
+
+		when(conversationRepository.findById(conversationId)).thenReturn(Optional.of(conversation));
+		when(messageRepository.findByConversationIdOrderByCreatedAtDesc(conversationId, pageable))
+				.thenReturn(new PageImpl<>(List.of(message)));
+		when(messageMapper.toMessageResponse(any(Message.class), any(UUID.class))).thenReturn(response);
+
+		Page<MessageResponse> result = messageService.getMessagesForConversation(conversationId, senderId, pageable);
+
+		assertEquals(1, result.getTotalElements());
+		assertEquals(response.getId(), result.getContent().getFirst().getId());
+	}
+
+	@Test
+	void saveMessageThrowsWhenConversationMissing() {
+		when(conversationRepository.findById(conversationId)).thenReturn(Optional.empty());
+
+		assertThrows(IllegalArgumentException.class,
+				() -> messageService.saveMessage(conversationId, senderId, "hello", List.of(), null, null));
+	}
+
+	@Test
+	void saveMessageThrowsWhenSenderNotParticipant() {
+		UUID outsider = UUID.randomUUID();
+		when(conversationRepository.findById(conversationId)).thenReturn(Optional.of(conversation));
+
+		assertThrows(IllegalArgumentException.class,
+				() -> messageService.saveMessage(conversationId, outsider, "hello", List.of(), null, null));
+	}
+
+	@Test
+	void saveMessageKeepsReplyReferenceWhenReplyExists() {
+		UUID replyToId = UUID.randomUUID();
+		UUID messageId = UUID.randomUUID();
+
+		Message saved = Message.builder()
+				.id(messageId)
+				.conversationId(conversationId)
+				.senderId(senderId)
+				.content("hello")
+				.replyToMessageId(replyToId)
+				.build();
+
+		MessageResponse mapped = MessageResponse.builder().id(messageId).build();
+
+		when(conversationRepository.findById(conversationId)).thenReturn(Optional.of(conversation));
+		when(messageRepository.existsByIdAndConversationId(replyToId, conversationId)).thenReturn(true);
+		when(messageRepository.saveAndFlush(any(Message.class))).thenReturn(saved);
+		when(mentionParserService.extractMentions("hello")).thenReturn(Set.of());
+		when(messageMapper.toMessageResponse(any(Message.class), any(UUID.class))).thenReturn(mapped);
+
+		messageService.saveMessage(conversationId, senderId, "hello", List.of(), replyToId, null);
+
+		ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
+		verify(messageRepository).saveAndFlush(captor.capture());
+		assertEquals(replyToId, captor.getValue().getReplyToMessageId());
+	}
+
+	@Test
+	void saveMessageDropsReplyReferenceWhenReplyMissing() {
+		UUID replyToId = UUID.randomUUID();
+		UUID messageId = UUID.randomUUID();
+
+		Message saved = Message.builder()
+				.id(messageId)
+				.conversationId(conversationId)
+				.senderId(senderId)
+				.content("hello")
+				.build();
+
+		MessageResponse mapped = MessageResponse.builder().id(messageId).build();
+
+		when(conversationRepository.findById(conversationId)).thenReturn(Optional.of(conversation));
+		when(messageRepository.existsByIdAndConversationId(replyToId, conversationId)).thenReturn(false);
+		when(messageRepository.saveAndFlush(any(Message.class))).thenReturn(saved);
+		when(mentionParserService.extractMentions("hello")).thenReturn(Set.of());
+		when(messageMapper.toMessageResponse(any(Message.class), any(UUID.class))).thenReturn(mapped);
+
+		messageService.saveMessage(conversationId, senderId, "hello", List.of(), replyToId, null);
+
+		ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
+		verify(messageRepository).saveAndFlush(captor.capture());
+		assertNull(captor.getValue().getReplyToMessageId());
+	}
+
+	@Test
+	void saveMessageLinksAttachmentsAndReloadsEntity() {
+		UUID messageId = UUID.randomUUID();
+		UUID attachmentId = UUID.randomUUID();
+		List<UUID> attachmentIds = List.of(attachmentId);
+
+		Message flushed = Message.builder()
+				.id(messageId)
+				.conversationId(conversationId)
+				.senderId(senderId)
+				.content("with attachment")
+				.build();
+
+		Message reloaded = Message.builder()
+				.id(messageId)
+				.conversationId(conversationId)
+				.senderId(senderId)
+				.content("with attachment")
+				.build();
+
+		MessageResponse mapped = MessageResponse.builder().id(messageId).build();
+
+		when(conversationRepository.findById(conversationId)).thenReturn(Optional.of(conversation));
+		when(messageRepository.saveAndFlush(any(Message.class))).thenReturn(flushed);
+		when(messageRepository.findById(messageId)).thenReturn(Optional.of(reloaded));
+		when(mentionParserService.extractMentions("with attachment")).thenReturn(Set.of());
+		when(messageMapper.toMessageResponse(any(Message.class), any(UUID.class))).thenReturn(mapped);
+
+		messageService.saveMessage(conversationId, senderId, "with attachment", attachmentIds, null, null);
+
+		verify(attachmentService).linkAttachmentsToMessage(attachmentIds, messageId, senderId);
+		verify(messageRepository).findById(messageId);
+	}
+
+	@Test
+	void saveMessagePersistsAndPublishesMentionsForValidParticipants() {
+		UUID messageId = UUID.randomUUID();
+		UUID mentionedUser = otherUserId;
+
+		Message saved = Message.builder()
+				.id(messageId)
+				.conversationId(conversationId)
+				.senderId(senderId)
+				.content("hi @" + mentionedUser)
+				.build();
+
+		MessageResponse mapped = MessageResponse.builder().id(messageId).build();
+
+		when(conversationRepository.findById(conversationId)).thenReturn(Optional.of(conversation));
+		when(messageRepository.saveAndFlush(any(Message.class))).thenReturn(saved);
+		when(mentionParserService.extractMentions(saved.getContent())).thenReturn(Set.of(mentionedUser, UUID.randomUUID()));
+		when(mentionParserService.validateMentions(anySet(), anySet())).thenReturn(Set.of(mentionedUser));
+		when(messageMapper.toMessageResponse(any(Message.class), any(UUID.class))).thenReturn(mapped);
+
+		messageService.saveMessage(conversationId, senderId, saved.getContent(), List.of(), null, null);
+
+		ArgumentCaptor<List<MessageMention>> mentionsCaptor = ArgumentCaptor.forClass(List.class);
+		verify(messageMentionRepository).saveAll(mentionsCaptor.capture());
+		assertEquals(1, mentionsCaptor.getValue().size());
+		assertEquals(mentionedUser, mentionsCaptor.getValue().getFirst().getMentionedUserId());
+
+		verify(messageEventPublisher).publishMentionEvent(
+				eq(messageId),
+				eq(conversationId),
+				eq(senderId),
+				eq(mentionedUser),
+				eq(saved.getContent())
+		);
+	}
+
+	@Test
+	void saveMessageSkipsMentionSaveWhenNoValidMentions() {
+		UUID messageId = UUID.randomUUID();
+
+		Message saved = Message.builder()
+				.id(messageId)
+				.conversationId(conversationId)
+				.senderId(senderId)
+				.content("no valid mentions")
+				.build();
+
+		MessageResponse mapped = MessageResponse.builder().id(messageId).build();
+
+		when(conversationRepository.findById(conversationId)).thenReturn(Optional.of(conversation));
+		when(messageRepository.saveAndFlush(any(Message.class))).thenReturn(saved);
+		when(mentionParserService.extractMentions(saved.getContent())).thenReturn(Set.of(UUID.randomUUID()));
+		when(mentionParserService.validateMentions(anySet(), anySet())).thenReturn(Set.of());
+		when(messageMapper.toMessageResponse(any(Message.class), any(UUID.class))).thenReturn(mapped);
+
+		messageService.saveMessage(conversationId, senderId, saved.getContent(), List.of(), null, null);
+
+		verify(messageMentionRepository, never()).saveAll(anyList());
+		verify(messageEventPublisher, never()).publishMentionEvent(any(), any(), any(), any(), any());
+	}
+
+	@Test
+	void editMessageThrowsWhenCallerIsNotSender() {
+		UUID messageId = UUID.randomUUID();
+		Message existing = Message.builder()
+				.id(messageId)
+				.conversationId(conversationId)
+				.senderId(senderId)
+				.content("hello")
+				.build();
+
+		when(messageRepository.findActiveById(messageId)).thenReturn(Optional.of(existing));
+
+		assertThrows(ForbiddenException.class,
+				() -> messageService.editMessage(messageId, UUID.randomUUID(), "updated"));
+	}
+
+	@Test
+	void editMessageUpdatesAndPublishesEvent() {
+		UUID messageId = UUID.randomUUID();
+		Message existing = Message.builder()
+				.id(messageId)
+				.conversationId(conversationId)
+				.senderId(senderId)
+				.content("hello")
+				.build();
+
+		MessageResponse mapped = MessageResponse.builder().id(messageId).content("updated").build();
+
+		when(messageRepository.findActiveById(messageId)).thenReturn(Optional.of(existing));
+		when(messageRepository.save(existing)).thenReturn(existing);
+		when(messageMapper.toMessageResponse(any(Message.class), any(UUID.class))).thenReturn(mapped);
+
+		MessageResponse result = messageService.editMessage(messageId, senderId, "updated");
+
+		assertEquals(messageId, result.getId());
+		assertEquals("updated", existing.getContent());
+		verify(messageEventPublisher).publishMessageEdited(
+				eq(messageId),
+				eq(conversationId),
+				eq(senderId),
+				eq("updated"),
+				eq(existing.getEditedAt())
+		);
+	}
+
+	@Test
+	void deleteMessageThrowsWhenCallerIsNeitherSenderNorAdmin() {
+		UUID messageId = UUID.randomUUID();
+		UUID outsider = UUID.randomUUID();
+
+		Message existing = Message.builder()
+				.id(messageId)
+				.conversationId(conversationId)
+				.senderId(senderId)
+				.content("hello")
+				.build();
+
+		when(messageRepository.findActiveById(messageId)).thenReturn(Optional.of(existing));
+		when(conversationService.isAdmin(conversationId, outsider)).thenReturn(false);
+
+		assertThrows(ForbiddenException.class,
+				() -> messageService.deleteMessage(messageId, outsider));
+	}
+
+	@Test
+	void deleteMessageAllowsSender() {
+		UUID messageId = UUID.randomUUID();
+
+		Message existing = Message.builder()
+				.id(messageId)
+				.conversationId(conversationId)
+				.senderId(senderId)
+				.content("hello")
+				.build();
+
+		when(messageRepository.findActiveById(messageId)).thenReturn(Optional.of(existing));
+		when(messageRepository.save(existing)).thenReturn(existing);
+
+		messageService.deleteMessage(messageId, senderId);
+
+		verify(messageEventPublisher).publishMessageDeleted(
+				eq(messageId),
+				eq(conversationId),
+				eq(senderId),
+				eq(existing.getDeletedAt())
+		);
+	}
+
+	@Test
+	void deleteMessageAllowsAdmin() {
+		UUID messageId = UUID.randomUUID();
+		UUID adminId = UUID.randomUUID();
+
+		Message existing = Message.builder()
+				.id(messageId)
+				.conversationId(conversationId)
+				.senderId(senderId)
+				.content("hello")
+				.build();
+
+		when(messageRepository.findActiveById(messageId)).thenReturn(Optional.of(existing));
+		when(conversationService.isAdmin(conversationId, adminId)).thenReturn(true);
+		when(messageRepository.save(existing)).thenReturn(existing);
+
+		messageService.deleteMessage(messageId, adminId);
+
+		verify(messageEventPublisher).publishMessageDeleted(
+				eq(messageId),
+				eq(conversationId),
+				eq(adminId),
+				eq(existing.getDeletedAt())
+		);
+	}
+
+	private ConversationParticipant participant(UUID convId, UUID userId) {
+		return ConversationParticipant.builder()
+				.id(ConversationParticipantId.builder()
+						.conversationId(convId)
+						.userId(userId)
+						.build())
+				.role(ConversationParticipant.ParticipantRole.MEMBER)
+				.joinedAt(LocalDateTime.now())
+				.build();
+	}
+}

--- a/backend/message-service/src/test/java/com/orang/messageservice/service/ReactionServiceTest.java
+++ b/backend/message-service/src/test/java/com/orang/messageservice/service/ReactionServiceTest.java
@@ -1,0 +1,198 @@
+package com.orang.messageservice.service;
+
+import com.orang.messageservice.dto.ReactionCountProjection;
+import com.orang.messageservice.entity.Message;
+import com.orang.messageservice.entity.MessageReaction;
+import com.orang.messageservice.entity.ReactionType;
+import com.orang.messageservice.repository.MessageReactionRepository;
+import com.orang.messageservice.repository.MessageRepository;
+import com.orang.shared.event.MessageReactionEvent;
+import com.orang.shared.exception.ResourceNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReactionServiceTest {
+
+    @Mock
+    private MessageReactionRepository reactionRepository;
+
+    @Mock
+    private MessageRepository messageRepository;
+
+    @Mock
+    private ConversationService conversationService;
+
+    @Mock
+    private MessageEventPublisher messageEventPublisher;
+
+    @InjectMocks
+    private ReactionService reactionService;
+
+    private UUID messageId;
+    private UUID userId;
+    private UUID conversationId;
+    private UUID messageAuthorId;
+
+    @BeforeEach
+    void setUp() {
+        messageId = UUID.randomUUID();
+        userId = UUID.randomUUID();
+        conversationId = UUID.randomUUID();
+        messageAuthorId = UUID.randomUUID();
+    }
+
+    @Test
+    void toggleReactionThrowsWhenMessageMissing() {
+        when(messageRepository.findActiveById(messageId)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> reactionService.toggleReaction(messageId, userId, ReactionType.LIKE));
+    }
+
+    @Test
+    void toggleReactionRemovesWhenSameReactionAlreadyExists() {
+        Message message = baseMessage();
+        MessageReaction existing = MessageReaction.builder()
+                .messageId(messageId)
+                .userId(userId)
+                .reactionType(ReactionType.LIKE)
+                .build();
+
+        when(messageRepository.findActiveById(messageId)).thenReturn(Optional.of(message));
+        when(reactionRepository.findByMessageIdAndUserId(messageId, userId)).thenReturn(Optional.of(existing));
+        when(reactionRepository.countByMessageIdGroupByType(messageId))
+                .thenReturn(List.of(projection(ReactionType.LIKE, 1L)));
+
+        Map<ReactionType, Long> result = reactionService.toggleReaction(messageId, userId, ReactionType.LIKE);
+
+        assertEquals(1L, result.get(ReactionType.LIKE));
+        verify(reactionRepository).delete(existing);
+        verify(messageEventPublisher).publishReactionChanged(
+                eq(messageId),
+                eq(conversationId),
+                eq(userId),
+                eq(MessageReactionEvent.Action.REMOVED),
+                eq(ReactionType.LIKE),
+                eq(result),
+                eq(messageAuthorId)
+        );
+    }
+
+    @Test
+    void toggleReactionChangesWhenDifferentReactionAlreadyExists() {
+        Message message = baseMessage();
+        MessageReaction existing = MessageReaction.builder()
+                .messageId(messageId)
+                .userId(userId)
+                .reactionType(ReactionType.SAD)
+                .build();
+
+        when(messageRepository.findActiveById(messageId)).thenReturn(Optional.of(message));
+        when(reactionRepository.findByMessageIdAndUserId(messageId, userId)).thenReturn(Optional.of(existing));
+        when(reactionRepository.countByMessageIdGroupByType(messageId))
+                .thenReturn(List.of(projection(ReactionType.HEART, 2L)));
+
+        Map<ReactionType, Long> result = reactionService.toggleReaction(messageId, userId, ReactionType.HEART);
+
+        assertEquals(ReactionType.HEART, existing.getReactionType());
+        assertEquals(2L, result.get(ReactionType.HEART));
+        verify(reactionRepository).save(existing);
+        verify(messageEventPublisher).publishReactionChanged(
+                eq(messageId),
+                eq(conversationId),
+                eq(userId),
+                eq(MessageReactionEvent.Action.CHANGED),
+                eq(ReactionType.HEART),
+                eq(result),
+                eq(messageAuthorId)
+        );
+    }
+
+    @Test
+    void toggleReactionAddsWhenNoReactionExists() {
+        Message message = baseMessage();
+
+        when(messageRepository.findActiveById(messageId)).thenReturn(Optional.of(message));
+        when(reactionRepository.findByMessageIdAndUserId(messageId, userId)).thenReturn(Optional.empty());
+        when(reactionRepository.countByMessageIdGroupByType(messageId))
+                .thenReturn(List.of(projection(ReactionType.ORANG, 1L)));
+
+        Map<ReactionType, Long> result = reactionService.toggleReaction(messageId, userId, ReactionType.ORANG);
+
+        assertEquals(1L, result.get(ReactionType.ORANG));
+        verify(reactionRepository).save(org.mockito.ArgumentMatchers.any(MessageReaction.class));
+        verify(messageEventPublisher).publishReactionChanged(
+                eq(messageId),
+                eq(conversationId),
+                eq(userId),
+                eq(MessageReactionEvent.Action.ADDED),
+                eq(ReactionType.ORANG),
+                eq(result),
+                eq(messageAuthorId)
+        );
+    }
+
+    @Test
+    void getReactionCountsFiltersOutNullRows() {
+        when(reactionRepository.countByMessageIdGroupByType(messageId))
+                .thenReturn(List.of(
+                        projection(ReactionType.LIKE, 3L),
+                        projection(null, 2L),
+                        projection(ReactionType.HEART, null)
+                ));
+
+        Map<ReactionType, Long> counts = reactionService.getReactionCounts(messageId);
+
+        assertEquals(1, counts.size());
+        assertEquals(3L, counts.get(ReactionType.LIKE));
+    }
+
+    @Test
+    void getReactionTypeReturnsOptionalFromRepository() {
+        when(reactionRepository.findByMessageIdAndUserId(messageId, userId))
+                .thenReturn(Optional.of(MessageReaction.builder().reactionType(ReactionType.WOW).build()));
+
+        Optional<ReactionType> type = reactionService.getReactionType(messageId, userId);
+
+        assertEquals(ReactionType.WOW, type.orElseThrow());
+    }
+
+    private Message baseMessage() {
+        return Message.builder()
+                .id(messageId)
+                .conversationId(conversationId)
+                .senderId(messageAuthorId)
+                .content("test")
+                .build();
+    }
+
+    private ReactionCountProjection projection(ReactionType type, Long count) {
+        return new ReactionCountProjection() {
+            @Override
+            public ReactionType getReactionType() {
+                return type;
+            }
+
+            @Override
+            public Long getCount() {
+                return count;
+            }
+        };
+    }
+}

--- a/backend/notification-service/src/main/java/com/orang/notificationservice/config/RabbitMQConfig.java
+++ b/backend/notification-service/src/main/java/com/orang/notificationservice/config/RabbitMQConfig.java
@@ -25,12 +25,16 @@ public class RabbitMQConfig {
     public static final String MESSAGE_NOTIFICATION_QUEUE = "notification.message.sent";
     public static final String REACTION_NOTIFICATION_QUEUE = "notification.reaction";
     public static final String MEMBER_ADDED_NOTIFICATION_QUEUE = "notification.member.added";
+    public static final String DIRECT_CONVERSATION_CREATED_NOTIFICATION_QUEUE =
+            RabbitMQConstants.DIRECT_CONVERSATION_CREATED_NOTIFICATION_QUEUE;
 
     // Routing keys (must match what publishers use!)
     public static final String MESSAGE_SENT_ROUTING_KEY = "message.sent";
     public static final String REACTION_ROUTING_KEY = "message.reaction";
     public static final String MEMBER_ADDED_ROUTING_KEY = "group.member.added";
     public static final String MENTION_ROUTING_KEY = "message.mention";
+    public static final String DIRECT_CONVERSATION_CREATED_ROUTING_KEY =
+            RabbitMQConstants.DIRECT_CONVERSATION_CREATED_KEY;
 
     @Bean
     public MessageConverter jsonMessageConverter() {
@@ -92,6 +96,11 @@ public class RabbitMQConfig {
     }
 
     @Bean
+    public Queue directConversationCreatedNotificationQueue() {
+        return QueueBuilder.durable(DIRECT_CONVERSATION_CREATED_NOTIFICATION_QUEUE).build();
+    }
+
+    @Bean
     public Queue contactRequestNotificationQueue() {
         return QueueBuilder.durable(RabbitMQConstants.CONTACT_REQUEST_NOTIFICATION_QUEUE).build();
     }
@@ -130,6 +139,14 @@ public class RabbitMQConfig {
                 .bind(mentionNotificationQueue())
                 .to(chatExchange())
                 .with(MENTION_ROUTING_KEY);
+    }
+
+    @Bean
+    public Binding directConversationCreatedNotificationBinding() {
+        return BindingBuilder
+                .bind(directConversationCreatedNotificationQueue())
+                .to(chatExchange())
+                .with(DIRECT_CONVERSATION_CREATED_ROUTING_KEY);
     }
 
     @Bean

--- a/backend/notification-service/src/main/java/com/orang/notificationservice/listener/NotificationEventListener.java
+++ b/backend/notification-service/src/main/java/com/orang/notificationservice/listener/NotificationEventListener.java
@@ -5,6 +5,7 @@ import com.orang.notificationservice.dto.NotificationPayload;
 import com.orang.notificationservice.service.WebPushService;
 import com.orang.shared.constants.RabbitMQConstants;
 import com.orang.shared.event.ContactRequestSentEvent;
+import com.orang.shared.event.DirectConversationCreatedEvent;
 import com.orang.shared.event.GroupMemberEvent;
 import com.orang.shared.event.MentionEvent;
 import com.orang.shared.event.MessageReactionEvent;
@@ -60,6 +61,43 @@ public class NotificationEventListener {
 
         } catch (Exception e) {
             log.error("Failed to process ContactRequestSentEvent: {}", e.getMessage(), e);
+        }
+    }
+
+    // =========================================================================
+    // Direct Conversation Notifications
+    // =========================================================================
+
+    @RabbitListener(queues = RabbitMQConfig.DIRECT_CONVERSATION_CREATED_NOTIFICATION_QUEUE)
+    public void handleDirectConversationCreated(DirectConversationCreatedEvent event) {
+        log.info("Received DirectConversationCreatedEvent: conversationId={}, initiatorId={}, recipientId={}",
+                event.getConversationId(), event.getInitiatorId(), event.getRecipientId());
+
+        if (event.getRecipientId() == null || event.getConversationId() == null) {
+            log.warn("DirectConversationCreatedEvent missing recipientId or conversationId - skipping notification");
+            return;
+        }
+
+        try {
+            NotificationPayload payload = NotificationPayload.builder()
+                    .title("New Chat")
+                    .body("Someone started a conversation with you")
+                    .icon("/icons/app-icon-192.png")
+                    .tag("direct-chat-created-" + event.getConversationId())
+                    .requireInteraction(true)
+                    .data(NotificationPayload.NotificationData.builder()
+                            .type("direct_chat_created")
+                            .conversationId(event.getConversationId())
+                            .url("/conversations/" + event.getConversationId())
+                            .build())
+                    .build();
+
+            webPushService.sendToUser(event.getRecipientId(), payload);
+
+            log.info("Sent direct chat created notification to user {} for conversation {}",
+                    event.getRecipientId(), event.getConversationId());
+        } catch (Exception e) {
+            log.error("Failed to process DirectConversationCreatedEvent: {}", e.getMessage(), e);
         }
     }
 

--- a/backend/notification-service/src/test/java/com/orang/notificationservice/listener/NotificationEventListenerTest.java
+++ b/backend/notification-service/src/test/java/com/orang/notificationservice/listener/NotificationEventListenerTest.java
@@ -3,6 +3,7 @@ package com.orang.notificationservice.listener;
 import com.orang.notificationservice.dto.NotificationPayload;
 import com.orang.notificationservice.service.WebPushService;
 import com.orang.shared.event.ContactRequestSentEvent;
+import com.orang.shared.event.DirectConversationCreatedEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,5 +51,29 @@ class NotificationEventListenerTest {
         assertThat(payload.getTag()).isEqualTo("contact-request-" + contactId);
         assertThat(payload.getData().getType()).isEqualTo("contact_request");
         assertThat(payload.getData().getUrl()).isEqualTo("/contacts/pending/incoming");
+    }
+
+    @Test
+    void handleDirectConversationCreatedSendsNotificationToRecipient() {
+        UUID conversationId = UUID.fromString("49b32d01-5a28-4013-b5a0-0651fe20adfd");
+        UUID initiatorId = UUID.fromString("844ec9f6-f781-4f67-aab0-1f33cf9734f7");
+        UUID recipientId = UUID.fromString("bc9e3f0b-8c33-4ef0-8c8d-b1d0f3f8f9d2");
+
+        listener.handleDirectConversationCreated(DirectConversationCreatedEvent.builder()
+                .conversationId(conversationId)
+                .initiatorId(initiatorId)
+                .recipientId(recipientId)
+                .build());
+
+        ArgumentCaptor<NotificationPayload> payloadCaptor = ArgumentCaptor.forClass(NotificationPayload.class);
+        verify(webPushService).sendToUser(eq(recipientId), payloadCaptor.capture());
+
+        NotificationPayload payload = payloadCaptor.getValue();
+        assertThat(payload.getTitle()).isEqualTo("New Chat");
+        assertThat(payload.getBody()).isEqualTo("Someone started a conversation with you");
+        assertThat(payload.getTag()).isEqualTo("direct-chat-created-" + conversationId);
+        assertThat(payload.getData().getType()).isEqualTo("direct_chat_created");
+        assertThat(payload.getData().getConversationId()).isEqualTo(conversationId);
+        assertThat(payload.getData().getUrl()).isEqualTo("/conversations/" + conversationId);
     }
 }

--- a/backend/shared-library/src/main/java/com/orang/shared/constants/RabbitMQConstants.java
+++ b/backend/shared-library/src/main/java/com/orang/shared/constants/RabbitMQConstants.java
@@ -11,6 +11,7 @@ public class RabbitMQConstants {
     public static final String USER_STATUS_QUEUE = "user.status.queue";
     public static final String NOTIFICATION_QUEUE = "notification.queue";
     public static final String CONTACT_REQUEST_NOTIFICATION_QUEUE = "notification.contact.request.queue";
+    public static final String DIRECT_CONVERSATION_CREATED_NOTIFICATION_QUEUE = "notification.direct.conversation.created.queue";
 
     public static final String MESSAGE_SENT_KEY = "message.sent";
     public static final String MESSAGE_DELIVERED_KEY = "message.delivered";
@@ -19,6 +20,7 @@ public class RabbitMQConstants {
     public static final String USER_OFFLINE_KEY = "user.offline";
     public static final String TYPING_INDICATOR_KEY = "typing.indicator";
     public static final String CONTACT_REQUEST_SENT_KEY = "contact.request.sent";
+    public static final String DIRECT_CONVERSATION_CREATED_KEY = "conversation.direct.created";
 
     private RabbitMQConstants() {}
 }


### PR DESCRIPTION
…p adds

add shared DirectConversationCreatedEvent with RabbitMQ routing key/queue constants publish direct conversation created event from message-service when a new DIRECT chat is created emit MEMBER_ADDED events for participants added during initial group creation consume direct chat created event in notification-service and send web push to recipient add/update unit tests for conversation event publishing and notification listener behavior